### PR TITLE
ebpf: Ensure the bounds of log buffer

### DIFF
--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-pub const LOG_BUF_CAPACITY: usize = 1024;
+pub const LOG_BUF_CAPACITY: usize = 8192;
 
 pub const LOG_FIELDS: usize = 7;
 

--- a/ebpf/aya-log-ebpf-macros/src/expand.rs
+++ b/ebpf/aya-log-ebpf-macros/src/expand.rs
@@ -92,6 +92,9 @@ pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStre
             let write_args = quote! {{
                 use ::aya_log_ebpf::WriteToBuf;
                 Ok::<_, ()>(record_len) #( .and_then(|record_len| {
+                    if record_len >= buf.buf.len() {
+                        return Err(());
+                    }
                     { #formatting_exprs }.write(&mut buf.buf[record_len..]).map(|len| record_len + len)
                 }) )*
             }};


### PR DESCRIPTION
eBPF verifier rejects programs which are not checking the bounds of the
log buffer before writing any arguments. This change ensures that
written log arguments.

In practice, it means that doing this kind of checks is not going to be
needed in eBPF program code anymore:

https://github.com/alessandrod/aya-echo-tracepoint/blob/33a1aee2eaa7503615a444ffa574dfba2be943f9/echo-ebpf/src/main.rs#L47

Tested on:

https://github.com/vadorovsky/aya-echo-tracepoint/tree/876f8b45511d0818b683de9a2196e8103b92e1a7

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>