### PR TITLE
lib: Add display hint for IPv4 addresses

### DIFF
--- a/aya-log/Cargo.toml
+++ b/aya-log/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 [dependencies]
 aya = { version = "0.11.0", features=["async_tokio"] }
 aya-log-common = { version = "0.1.11-dev.0", path = "../aya-log-common", features=["userspace"] }
-dyn-fmt = "0.3.0"
 thiserror = "1"
 log = "0.4"
 bytes = "1.1"


### PR DESCRIPTION
This change adds optional display hints `{:ipv4}` and `{:IPv4}` for
displaying u32 as IPv4 addresses. It also gets rid of dyn-fmt and
instead comes with our own parser implementation.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>