### PR TITLE
Fix the log buffer bounds

### DIFF
--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -90,9 +90,9 @@ where
 
     pub(crate) fn write(&self, mut buf: &mut [u8]) -> Result<usize, ()> {
         let size = mem::size_of::<T>() + mem::size_of::<usize>() + self.value.len();
-        // The verifier rejects the program if it can't see that `size` doesn't
-        // exceed the buffer size.
-        if size > LOG_BUF_CAPACITY {
+        let remaining = cmp::min(buf.len(), LOG_BUF_CAPACITY);
+        // Check if the size doesn't exceed the buffer bounds.
+        if size > remaining {
             return Err(());
         }
 
@@ -103,8 +103,8 @@ where
         buf = &mut buf[mem::size_of::<usize>()..];
 
         let len = cmp::min(buf.len(), self.value.len());
-        // The verifier rejects the program if it can't see that `size` doesn't
-        // exceed the buffer size.
+        // The verifier isn't happy with `len` being unbounded, so compare it
+        // with `LOG_BUF_CAPACITY`.
         if len > LOG_BUF_CAPACITY {
             return Err(());
         }


### PR DESCRIPTION
Change 150ee798e609 removed the `size > buf.len()` check, which was a
mistake, because we might write to a subslice of the whole buffer, so
then `buf` can be lower than `LOG_BUF_CAPACITY`.

This change compares `size` with `min::(buf.len(), LOG_BUF_CAPACITY)`
instead.

Fixes: 150ee798e609 ("Ensure log buffer bounds")
Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>